### PR TITLE
Added node-slackr and ioredis

### DIFF
--- a/package.json.j2
+++ b/package.json.j2
@@ -5,6 +5,8 @@
     "dependencies": {
         "request": "*",
         "promise": "^7.0.1",
+        "node-slackr": "^0.1.0",
+        "ioredis": "^1.6.1",
 
         {% for machinepack in machinepacks %}"{{ machinepack }}": "*",
         {% endfor %}


### PR DESCRIPTION
Added `node-slackr` which previously was added only in package.json (needs to be here too or will be overwritten) and `ioredis` needed for Fastack development.
