### PR TITLE
Fix syncano-js-4 version

### DIFF
--- a/package.json.j2
+++ b/package.json.j2
@@ -11,7 +11,7 @@
         {% for machinepack in machinepacks %}"{{ machinepack }}": "*",
         {% endfor %}
 
-        "syncano-js-4": "^4.1.3",
+        "syncano-js-4": "^4.1.4",
         "syncano": "~0.2.1"
     }
 }


### PR DESCRIPTION
syncano-js-4 version should be the same in `package.json.j2` as in `package.json`
