### PR TITLE
Added adm-zip to dependencies

### DIFF
--- a/package.json.j2
+++ b/package.json.j2
@@ -40,6 +40,7 @@
     "winston": "^2.2.0", 
     "winston-daily-rotate-file": "^1.0.1",
     "plaid": "~1.0.10",
+    "adm-zip": "^0.4.7",
 
     {% for machinepack in machinepacks %}"{{ machinepack }}": "*",
     {% endfor %}


### PR DESCRIPTION
Adding `adm-zip` dependency in order to enable creating zip files placed inside Syncano.
