### PR TITLE
Update Plaid version to 1.1.1

### DIFF
--- a/nodejs/files/package.json.j2
+++ b/nodejs/files/package.json.j2
@@ -40,7 +40,7 @@
     "q": "1.1.2", 
     "winston": "^2.2.0", 
     "winston-daily-rotate-file": "^1.0.1",
-    "plaid": "~1.0.10",
+    "plaid": "~1.1.0",
     "adm-zip": "^0.4.7",
 
     {% for machinepack in machinepacks %}"{{ machinepack }}": "*",

--- a/nodejs/files/package.json.j2
+++ b/nodejs/files/package.json.j2
@@ -40,7 +40,7 @@
     "q": "1.1.2", 
     "winston": "^2.2.0", 
     "winston-daily-rotate-file": "^1.0.1",
-    "plaid": "~1.1.0",
+    "plaid": "~1.1.1",
     "adm-zip": "^0.4.7",
 
     {% for machinepack in machinepacks %}"{{ machinepack }}": "*",

--- a/nodejs/files/package.json.v10
+++ b/nodejs/files/package.json.v10
@@ -40,7 +40,7 @@
     "q": "1.1.2", 
     "winston": "^2.2.0", 
     "winston-daily-rotate-file": "^1.0.1",
-    "plaid": "~1.1.0",
+    "plaid": "~1.1.1",
     "adm-zip": "^0.4.7",
 
     "dk-machinepack-facebookads": "~1.3.31",

--- a/nodejs/files/package.json.v10
+++ b/nodejs/files/package.json.v10
@@ -40,7 +40,7 @@
     "q": "1.1.2", 
     "winston": "^2.2.0", 
     "winston-daily-rotate-file": "^1.0.1",
-    "plaid": "~1.0.10",
+    "plaid": "~1.1.0",
     "adm-zip": "^0.4.7",
 
     "dk-machinepack-facebookads": "~1.3.31",


### PR DESCRIPTION
This version adds support for the new `institutions/all` and `institutions/all/search` endpoints.